### PR TITLE
Set containers' hostname

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     firewall:
         privileged: true
         container_name : Firewall
+        hostname: Firewall
         build: .
         cap_add : 
             - NET_ADMIN 
@@ -28,6 +29,7 @@ services:
     client_in_lan:
         privileged: true
         container_name : Client_in_LAN
+        hostname: Client_in_LAN
         build: .
         cap_add : 
             - NET_ADMIN
@@ -47,6 +49,7 @@ services:
     server_in_dmz:
         privileged: true
         container_name : Server_in_DMZ
+        hostname: Server_in_DMZ
         build: .
         cap_add : 
             - NET_ADMIN


### PR DESCRIPTION
Useful when we execute multiple /bin/bash instances (docker exec -it ...) on the containers.

Example : `docker exec -it Server_in_DMZ /bin/bash`
old behaviour: `root@4g570fd04cf1:/#`
new behaviour: `root@Server_in_DMZ:/#`